### PR TITLE
Fix ssh_concourse Makefile target

### DIFF
--- a/concourse/scripts/ssh.sh
+++ b/concourse/scripts/ssh.sh
@@ -37,7 +37,7 @@ download_key() {
   key=/tmp/concourse_id_rsa.$RANDOM
   trap 'rm -f $key' EXIT
 
-  eval "$(make "${AWS_ACCOUNT}" showenv | grep CONCOURSE_IP=)"
+  eval "$(make "${MAKEFILE_ENV_TARGET}" showenv | grep CONCOURSE_IP=)"
   aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/concourse_id_rsa" $key && chmod 400 $key
 }
 


### PR DESCRIPTION
## What

The `AWS_ACCOUNT` environment variable has the same value for different
persistent environments, and therefore cannot be used here. We must have
forgot to update it when we added the London environments.

How to review
-------------

Check you can SSH into Concourse in:

* your dev
* staging 
* Ireland prod
* London prod

Who can review
--------------

Anyone but me.
