### PR TITLE
[FIREBREAK] Update the ssh command for 'ssh_bosh'

### DIFF
--- a/scripts/bosh-cli.sh
+++ b/scripts/bosh-cli.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 tunnel_mux='/tmp/bosh-ssh-tunnel.mux'
 
-function cleanup () {
+function cleanup() {
   echo 'Closing SSH tunnel'
   ssh -S "$tunnel_mux" -O exit a-destination &>/dev/null || true
 
@@ -20,13 +20,14 @@ BOSH_CA_CERT="$(aws s3 cp "s3://gds-paas-${DEPLOY_ENV}-state/bosh-CA.crt" -)"
 
 echo 'Opening SSH tunnel'
 ssh -qfNC -4 -D 25555 \
+  -o Hostname="bosh-external.${SYSTEM_DNS_ZONE_NAME}" \
   -o ExitOnForwardFailure=yes \
   -o StrictHostKeyChecking=no \
   -o UserKnownHostsFile=/dev/null \
   -o ServerAliveInterval=30 \
   -M \
   -S "$tunnel_mux" \
-  "bosh-external.${SYSTEM_DNS_ZONE_NAME}" \
+  paas_bosh_ssh
 
 export BOSH_CA_CERT
 export BOSH_ALL_PROXY="socks5://localhost:25555"

--- a/scripts/ssh_bosh.sh
+++ b/scripts/ssh_bosh.sh
@@ -11,7 +11,8 @@ echo
 
 # shellcheck disable=SC2029
 ssh \
+    -o Hostname="${BOSH_IP}" \
     -o ServerAliveInterval=60 \
     -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null \
-    "$USER"@"$BOSH_IP"
+    paas_bosh_ssh


### PR DESCRIPTION
What
----

Before, we were ssh'ing directly to the bosh ip, which is difficult to set up ssh_config for.

This way, we ssh to `paas_bosh_ssh', but set the hostname to the IP we are ssh'ing to.

~/.ssh/config can then be set up for this fake hostname.
```
Host paas_bosh_ssh
	User xxxx
	IdentityFile %d/.ssh/xyz.pub
```

Specifying the user for the SSH to `${USER}` is unnecessary, as this is the default behaviour of SSH, and makes it impossible to override with ssh_config. Also, as `$USER` is not immutable, it's not a security improvement.

This is an improvement which allows for cases where there are a large number of ssh keys in the agent ie. if using [1Password's agent](https://developer.1password.com/docs/ssh/).
In this case, if the needed key is too far down the list, the attempts with invalid keys leads to an authfail before the correct one is tried.

How to review
-------------

1. Run `gds aws $role -- make ssh_bosh DEPLOY_ENV=$env` before and after checking out this branch, and ensure there are no changes.
1. Update your ssh config, as-in my example, and then run the `make` command again. You should see an error, as the username / key are incorrect.
1. Remove the ssh config again, and note that SSH'ing works again.

Who can review
--------------

Not me

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
