### PR TITLE
[#185156395] Upgrade stemcell to 1.108

### DIFF
--- a/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
+++ b/manifests/bosh-manifest/operations.d/030-set-stemcell.yml
@@ -2,5 +2,5 @@
 - type: replace
   path: /resource_pools/name=vms/stemcell
   value:
-    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-jammy-go_agent?v=1.102
-    sha1: 59fee45991ac623eff1c25d25b3c6509293bfd50
+    url: https://bosh.io/d/stemcells/bosh-aws-xen-hvm-ubuntu-jammy-go_agent?v=1.108
+    sha1: 0298916ca90ff4da1134327187020db234f8cdf9

--- a/manifests/concourse-manifest/concourse-base.yml
+++ b/manifests/concourse-manifest/concourse-base.yml
@@ -2,7 +2,7 @@
 meta:
   stemcell:
     name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
-    version: "1.102"
+    version: "1.108"
 
 name: concourse
 


### PR DESCRIPTION
What
----

Upgrade stemcell to 1.108. This is being expedited due [to this issue](https://github.com/cloudfoundry/bosh-linux-stemcell-builder/pull/287) in 1.102.

How to review
-------------

Tested in dev-05:
- [bosh-deploy](https://deployer.dev05.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/bosh-deploy/builds/5#L6453e275:40)
- [concourse-deploy](https://deployer.dev05.dev.cloudpipeline.digital/teams/main/pipelines/create-bosh-concourse/jobs/concourse-deploy/builds/7#L6453e29b:15)

Who can review
--------------

Any sre.

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
