### PR TITLE
Update envrionment bootstrap scripts

### DIFF
--- a/manifests/bosh-manifest/operations.d/040-cloud-provider.yml
+++ b/manifests/bosh-manifest/operations.d/040-cloud-provider.yml
@@ -1,6 +1,6 @@
 - type: replace
   path: /cloud_provider/mbus
-  value: "https://mbus:((mbus_bootstrap_password))@((bosh_fqdn_external)):6868"
+  value: "https://mbus:((mbus_bootstrap_password))@((bosh_fqdn)):6868"
 
 - type: replace
   path: /cloud_provider/properties/agent/mbus

--- a/vagrant/post-deploy.d/00-run-docker.sh
+++ b/vagrant/post-deploy.d/00-run-docker.sh
@@ -4,19 +4,7 @@ set -eu
 
 export DEBIAN_FRONTEND=noninteractive
 
-echo "Waiting for cloud-init to update /etc/apt/sources.list .." >&2
-until grep -q ec2.archive.ubuntu.com /etc/apt/sources.list; do
-  sleep 2
-  echo ".. still waiting .." >&2
-done
-echo ".. update complete." >&2
-
 sudo -E apt-get update && sudo -E apt-get install docker-compose -y
-
-cd /vagrant
-
-# shellcheck disable=SC2091
-$(./environment.sh)
 
 # Expose settings as the envvars which the upstream docker-compose file expects
 export CONCOURSE_POSTGRES_DATABASE="$CONCOURSE_DATABASE_NAME"


### PR DESCRIPTION
What
----

* the bosh director mbus can only be connected to over it's internal hostname/IP address
* we don't need to wait for the apt sources to be updated, and the location of the apt sources list has changed
* we don't need to run the environment script anymore when running docker, as we will have already sourced the environment

---

🚨⚠️ Please do not merge this pull request via the GitHub UI ⚠️🚨
